### PR TITLE
US439108 - Updated OpenSUSE to version 15.4

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -17,7 +17,7 @@
 # Docker registry
 ARG DOCKER_HUB_PUBLIC=docker.io
 
-FROM ${DOCKER_HUB_PUBLIC}/cafapi/buildenv-jdk8:1.0.0
+FROM ${DOCKER_HUB_PUBLIC}/cafapi/prereleases:buildenv-jdk8-2.0.0-SNAPSHOT
 CMD ["bash"]
 
 RUN zypper -n install libicu wget


### PR DESCRIPTION
Getting conflict issue at the time of building [new environment](https://github.com/CAFapi/buildenv-dotnet-mono-image) using this environment. So updated OpenSUSE to latest v15.4.